### PR TITLE
コメント編集/削除

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -29,7 +29,8 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-
+    @comment.destroy
+    redirect_to @post
   end
 
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -24,6 +24,7 @@ class CommentsController < ApplicationController
     if @comment.update(comment_params)
       redirect_to @post
     else
+      flash.now[:alert] = "コメントを(140文字以内で)入力してください。"
       render "posts/show"
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,6 @@
 class CommentsController < ApplicationController
-  before_action :set_post
+  before_action :set_post, only: [:create,:edit,:update,:destroy]
+  before_action :set_comment, only: [:edit,:update,:destroy]
 
   def new
     @comment = Comment.new
@@ -15,12 +16,32 @@ class CommentsController < ApplicationController
     end
   end
 
+  def edit
+    render "posts/show"
+  end
+  
+  def update
+    if @comment.update(comment_params)
+      redirect_to @post
+    else
+      render "posts/show"
+    end
+  end
+
+  def destroy
+
+  end
+
   private
   def set_post
     @post = Post.find(params[:post_id])
   end
 
+  def set_comment
+    @comment = Comment.find(params[:id])
+  end
+
   def comment_params
-    params.require(:comment).permit(:content, :post_id, :user_id)
+    params.require(:comment).permit(:comment, :post_id, :user_id)
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
   before_action :check_guest, only: %i[update destroy]
 
@@ -42,9 +42,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # protected
 
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :password])
-  # end
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :password])
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,7 +2,7 @@ class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
 
-  validates :content, presence: true, length: { maximum: 140 }
+  validates :comment, presence: true, length: { maximum: 140 }
 
   scope :sorted_desc, -> { order(created_at: :desc) }
   scope :includes_user, -> { includes(:user) }

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -57,12 +57,12 @@
               </div>
               <div class="comment_area__list__comment__right_box">
                 <div class="comment_area__list__comment__right_box__info">
-                  編集
-                  削除
+                  <span><%= link_to "編集", edit_post_comment_path(id: comment.id,post_id: comment.post.id ) %></span>
+                  <span><%= link_to "削除", "#" %></span>
                   <span>投稿日時：<%= comment.created_at.strftime("%Y-%m-%d %H:%M") %></span>
                 </div>
                 <div class="comment_area__list__comment__right_box__text">
-                  <span><%= comment.content %></span>
+                  <span><%= comment.comment %></span>
                 </div>
               </div>
             </li>
@@ -74,7 +74,7 @@
         <div class="comment_area__form_box">
           <%= form_with model: [@post,@comment], local: true, class:"comment_area__form_box__form" do |f| %>
             <div class="comment_area__form_box__form__field">
-              <%= f.text_area :content, placeholder: "コメントを入力" %>
+              <%= f.text_area :comment, placeholder: "コメントを入力" %>
             </div>
             <div class="comment_area__form_box__form__hidden_field">
               <%= f.hidden_field :user_id, :value => current_user.id %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -34,7 +34,7 @@
             </li>
             <li>
               <i class="far fa-heart"></i>
-              <span>2</span>
+              <span>いいね</span>
             </li>
           </ul>
           <div class="post_detail__bottom_box__admin_actions">
@@ -58,7 +58,7 @@
               <div class="comment_area__list__comment__right_box">
                 <div class="comment_area__list__comment__right_box__info">
                   <span><%= link_to "編集", edit_post_comment_path(id: comment.id,post_id: comment.post.id ) %></span>
-                  <span><%= link_to "削除", "#" %></span>
+                  <span><%= link_to "削除", post_comment_path(id: comment.id, post_id: comment.post.id), method: :delete, data: { confirm: "本当に削除していいですか？", cancel: "やめる", commit: "削除する" }, title: "削除確認" %></span>
                   <span>投稿日時：<%= comment.created_at.strftime("%Y-%m-%d %H:%M") %></span>
                 </div>
                 <div class="comment_area__list__comment__right_box__text">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -57,8 +57,10 @@
               </div>
               <div class="comment_area__list__comment__right_box">
                 <div class="comment_area__list__comment__right_box__info">
+                <% if user_signed_in? && comment.user == current_user %>
                   <span><%= link_to "編集", edit_post_comment_path(id: comment.id,post_id: comment.post.id ) %></span>
                   <span><%= link_to "削除", post_comment_path(id: comment.id, post_id: comment.post.id), method: :delete, data: { confirm: "本当に削除していいですか？", cancel: "やめる", commit: "削除する" }, title: "削除確認" %></span>
+                <% end %>
                   <span>投稿日時：<%= comment.created_at.strftime("%Y-%m-%d %H:%M") %></span>
                 </div>
                 <div class="comment_area__list__comment__right_box__text">

--- a/db/migrate/20201108011511_create_comments.rb
+++ b/db/migrate/20201108011511_create_comments.rb
@@ -1,7 +1,7 @@
 class CreateComments < ActiveRecord::Migration[5.2]
   def change
     create_table :comments do |t|
-      t.string :content
+      t.string :comment
       t.references :user, foreign_key: true
       t.references :post, foreign_key: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_19_120019) do
+ActiveRecord::Schema.define(version: 2020_11_08_011511) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "comments", force: :cascade do |t|
-    t.string "content"
+    t.string "comment"
     t.bigint "user_id"
     t.bigint "post_id"
     t.datetime "created_at", null: false

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  content: MyString
+  comment: MyString
   user: one
   post: one
 
 two:
-  content: MyString
+  comment: MyString
   user: two
   post: two


### PR DESCRIPTION
【実装内容】
・コメント内容を変更できる
・コメントを削除できる
・上記2つができるのは投稿者のみに限定
・編集画面を開いた際、既に登録されているコメントを表示させる
・バリデーション投稿内容必須（ブランク投稿不可）＆140文字以内
・バリーデションに反した場合、エラーメッセージを表示
